### PR TITLE
Python 3 SyntaxError Fix

### DIFF
--- a/phue_lib.py
+++ b/phue_lib.py
@@ -692,7 +692,7 @@ class Bridge(object):
 
         ip = str(data[0]['internalipaddress'])
 
-        if ip is not '':
+        if ip != '':
             if set_result:
                 self.ip = ip
 


### PR DESCRIPTION
Fixed "'is not' with a literal" Python 3 syntax error